### PR TITLE
logging and comment update_project_item

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3,8 +3,10 @@ from flask import Flask
 import utils as utils
 
 app = Flask(__name__)
-logging.basicConfig(level=logging.DEBUG, format=f'%(asctime)s %(levelname)s %(name)s %(threadName)s : %(message)s')
-app_logger = app.logger
+
+logging.getLogger("requests").setLevel(logging.WARNING)
+logging.basicConfig(level=logging.INFO, format=f'[%(asctime)s] %(filename)s:%(lineno)d %(levelname)s - '
+                                                f'%(message)s')
 
 
 @app.route('/sync-projects')

--- a/src/utils.py
+++ b/src/utils.py
@@ -7,6 +7,9 @@ from datetime import timedelta
 from oms_jira import MPClient
 from oms_jira.services.mp import MPMessage, ScopeEnum, MessageAuthor, ProjectItemStatusEnum
 from waldur_client import WaldurClient
+from src.app import app
+
+app_logger = app.logger
 
 EOSC_URL = os.environ.get('EOSC_URL')  # polling url
 TOKEN = os.environ.get('TOKEN')
@@ -23,6 +26,7 @@ def get_waldur_token():
     WALDUR_AUTH = {'username': USERNAME, 'password': PASSWORD}
     re = requests.post(WALDUR_API_AUTH, data=WALDUR_AUTH)
     content = re.json()
+    app_logger.info('GET WALDUR TOKEN')
     return content['token']
 
 
@@ -40,6 +44,7 @@ def get_time(time_delta=timedelta(days=20)):
 
 def get_events():
     events = mp.list_events(get_time(), limit=None)
+    app_logger.info('GET events from EOSC MP')
     return events
 
 
@@ -51,40 +56,62 @@ def post_message(project_item_data, content):
     msg = MPMessage(project_id=project_item_data.project_id,
                     project_item_id=project_item_data.id,
                     author=msg_author,
-                    content=str(content),
+                    content=content,
                     scope=ScopeEnum.public)
 
     # return mp.create_message(message=msg)
-    return mp.post(mp.endpoint.message_list, data=msg.dict(), verify=False)
+    try:
+        post_message_data = mp.post(mp.endpoint.message_list, data=msg.dict())
+    except ValueError:
+        app_logger.error(f'Message for new order {project_item_data.id} for project '
+                         f'{project_item_data.project_id} was NOT posted')
+    else:
+        app_logger.info(f'Message for new order {project_item_data.id} for project '
+                        f'{project_item_data.project_id} was posted')
+        return post_message_data
 
 
-def patch_project_item(project_item_data, event_data):
-    # for change in event_data.changes:
-    #     mp.update_project_item(project_id=project_item_data.project_id,
-    #                            project_item_id=project_item_data.project_item_id,
-    #                            status=ProjectItemStatusEnum(ProjectItemStatusEnum(change.after)),
-    #                            )
-    mp.patch(mp.endpoint.project_item.format(
-        project_id=project_item_data.project_id, project_item_id=project_item_data.id), verify=False,
-        data={"status": {"value": "registered",
-                         "type": "registered"},
-              # "user_secrets": {"access credentials": WALDUR_TOKEN}
-              },
-    )
+def patch_project_item(project_item_data):
+    try:
+        patch_project_item_data = mp.patch(mp.endpoint.project_item.format(
+            project_id=project_item_data.project_id,
+            project_item_id=project_item_data.id),
+            verify=False,
+            data={
+                # "user_secrets": {"access credentials": WALDUR_TOKEN}
+            },
+        )
+    except ValueError:
+        app_logger.error(f'Project item {project_item_data.id} from project '
+                         f'{project_item_data.project_id} was NOT patched. '
+                         f'Value: {patch_project_item_data["data"]}')
+    else:
+        app_logger.info(f'Project item {project_item_data.id} from project '
+                        f'{project_item_data.project_id} was patched. '
+                        f'Value: {patch_project_item_data["data"]}')
+        return patch_project_item_data
 
 
 def update_project_item(project_item_data, event_data):
+    # TODO check if was already updated
     for change in event_data.changes:
         # for testing purposes because of invalid test input in eosc mp
-        if change.before or change.after == '<OBFUSCATED>':
-            pass
+        try:
+            update_project_item_data = mp.update_project_item(project_id=project_item_data.project_id,
+                                                              project_item_id=project_item_data.id,
+                                                              status=ProjectItemStatusEnum(change.after))
+        except ValueError:
+            app_logger.error(f'Project item {project_item_data.id} from project '
+                             f'{project_item_data.project_id} was NOT updated. '
+                             f'{change.field}: {change.before} -> {change.after}')
         else:
-            mp.update_project_item(project_id=project_item_data.project_id,
-                                   project_item_id=project_item_data.id,
-                                   status=ProjectItemStatusEnum(change.after))
+            app_logger.info(f'Project item {project_item_data.id} from project '
+                            f'{project_item_data.project_id} was updated. '
+                            f'{change.field}: {change.before} -> {change.after}')
+            return update_project_item_data
 
 
-def get_or_create_order(offering_data, project_data_for_order, project_item_data, event_data):
+def get_or_create_order(offering_data, project_data_for_order, project_item_data):
     order_filter_list = wc.list_orders({'project_uuid': str(project_data_for_order['uuid'])})
     if len(order_filter_list) != 0:
         return order_filter_list[0]
@@ -102,37 +129,49 @@ def get_or_create_order(offering_data, project_data_for_order, project_item_data
     post_message(project_item_data=project_item_data,
                  content=content)
 
-    patch_project_item(project_item_data=project_item_data, event_data=event_data)
+    patch_project_item(project_item_data=project_item_data)
     return order_data
-
-
-def get_or_create_order_item():
-    pass
 
 
 def get_or_create_project(project_data, customer_data):
     project_filter_list = wc.list_projects({'backend_id': str(project_data.id)})
     if len(project_filter_list) != 0:
+        app_logger.info(f'Project with backend_id {project_data.id} is already in WALDUR, '
+                        f'name: {project_filter_list[0]["name"]}.')
         return project_filter_list[0]
-
-    return wc.create_project(customer_uuid=customer_data['uuid'],
-                             name=project_data.attributes.name,
-                             backend_id=str(project_data.id))
+    try:
+        create_project_data = wc.create_project(customer_uuid=customer_data['uuid'],
+                                                name=project_data.attributes.name,
+                                                backend_id=str(project_data.id))
+    except ValueError:
+        app_logger.error(f'Cannot create project with id {project_data.id}')
+    else:
+        app_logger.info(f'Project with backend_id {project_data.id} was created in WALDUR. '
+                        f'Name of the project: {project_data.attributes.name}. '
+                        f'Customer name: {project_data.attributes.organization}.')
+        return create_project_data
 
 
 def get_or_create_customer_for_project(project_data):
     customers_filter_list = wc.list_customers({'name_exact': project_data.attributes.organization})
     if len(customers_filter_list) != 0:
+        app_logger.info(f'Customer named {project_data.attributes.organization} is already in WALDUR.')
         return customers_filter_list[0]  # data of existing customer with this name
-
-    return wc.create_customer(name=project_data.attributes.organization,  # data of a new customer
-                              email=project_data.owner.email,
-                              backend_id=project_data.attributes.organization,
-                              country=pycountry.countries.get(name=project_data.attributes.country).alpha_2,
-                              domain=project_data.attributes.department_webpage,
-                              homepage=project_data.attributes.department_webpage,
-                              native_name=project_data.attributes.organization,
-                              )
+    try:
+        create_customer_data = wc.create_customer(name=project_data.attributes.organization,  # data of a new customer
+                                                  email=project_data.owner.email,
+                                                  backend_id=project_data.attributes.organization,
+                                                  country=pycountry.countries.get(
+                                                      name=project_data.attributes.country).alpha_2,
+                                                  domain=project_data.attributes.department_webpage,
+                                                  homepage=project_data.attributes.department_webpage,
+                                                  native_name=project_data.attributes.organization,
+                                                  )
+    except ValueError:
+        app_logger.error(f'Cannot customer named {project_data.attributes.organization}.')
+    else:
+        app_logger.info(f'Customer named {project_data.attributes.organization} was created in WALDUR.')
+        return create_customer_data
 
 
 def sync_projects():
@@ -157,7 +196,6 @@ def sync_projects():
     pass
 
 
-# TODO
 def sync_orders():
     for event in get_events():
         if event.resource == 'project_item':
@@ -165,16 +203,18 @@ def sync_orders():
             customer_data = get_or_create_customer_for_project(project_data=project_data)
             if event.type == 'create':
                 offering_data = wc._get_offering(offering="3a878cee7bb749d0bb258d7b8442cb64")  # hardcoded
+                app_logger.info(f'Using offering {offering_data["name"]}.')
                 project_data_for_order = get_or_create_project(project_data=project_data,
                                                                customer_data=customer_data)
                 project_item_data = mp.get_project_item(event.project_id, event.project_item_id)
                 get_or_create_order(offering_data=offering_data,
                                     project_data_for_order=project_data_for_order,
-                                    project_item_data=project_item_data,
-                                    event_data=event)
+                                    project_item_data=project_item_data)
             if event.type == 'update':
-                project_item_data = mp.get_project_item(event.project_id, event.project_item_id)
-                update_project_item(project_item_data=project_item_data, event_data=event)
+                # Nothing in waldur
+                # project_item_data = mp.get_project_item(event.project_id, event.project_item_id)
+                # update_project_item(project_item_data=project_item_data, event_data=event)
+                pass
             if event.type == 'delete':
                 # TODO
                 pass


### PR DESCRIPTION
```
[2021-08-03 16:25:32,472] utils.py:29 INFO - GET WALDUR TOKEN
[2021-08-03 16:25:32,478] _internal.py:225 WARNING -  * Debugger is active!
[2021-08-03 16:25:32,484] _internal.py:225 INFO -  * Debugger PIN: 474-459-700
[2021-08-03 16:25:39,971] utils.py:47 INFO - GET events from EOSC MP
[2021-08-03 16:25:40,117] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:40,179] utils.py:139 INFO - Project with backend_id 1449 is already in WALDUR, name: TEST.
[2021-08-03 16:25:40,333] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:40,395] utils.py:139 INFO - Project with backend_id 1450 is already in WALDUR, name: TEST2.
[2021-08-03 16:25:40,545] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:40,610] utils.py:139 INFO - Project with backend_id 1451 is already in WALDUR, name: TEST3.
[2021-08-03 16:25:40,765] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:40,828] utils.py:139 INFO - Project with backend_id 1452 is already in WALDUR, name: TEST4.
[2021-08-03 16:25:40,828] app.py:15 INFO - sync_projects is finished
[2021-08-03 16:25:40,829] _internal.py:225 INFO - 127.0.0.1 - - [03/Aug/2021 16:25:40] "GET /sync-projects HTTP/1.1" 200 -
[2021-08-03 16:25:46,122] utils.py:47 INFO - GET events from EOSC MP
[2021-08-03 16:25:46,278] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:46,357] utils.py:206 INFO - Using offering Nordic Test Resource 1.
[2021-08-03 16:25:46,421] utils.py:139 INFO - Project with backend_id 1449 is already in WALDUR, name: TEST.
[2021-08-03 16:25:46,733] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:46,889] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:46,968] utils.py:206 INFO - Using offering Nordic Test Resource 1.
[2021-08-03 16:25:47,032] utils.py:139 INFO - Project with backend_id 1450 is already in WALDUR, name: TEST2.
[2021-08-03 16:25:47,342] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:47,494] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:47,645] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:47,727] utils.py:206 INFO - Using offering Nordic Test Resource 1.
[2021-08-03 16:25:47,787] utils.py:139 INFO - Project with backend_id 1451 is already in WALDUR, name: TEST3.
[2021-08-03 16:25:48,107] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:48,258] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:48,346] utils.py:206 INFO - Using offering Nordic Test Resource 1.
[2021-08-03 16:25:48,410] utils.py:139 INFO - Project with backend_id 1452 is already in WALDUR, name: TEST4.
[2021-08-03 16:25:48,757] utils.py:158 INFO - Customer named ETAIS is already in WALDUR.
[2021-08-03 16:25:48,757] app.py:22 INFO - sync_orders is finished
[2021-08-03 16:25:48,757] _internal.py:225 INFO - 127.0.0.1 - - [03/Aug/2021 16:25:48] "GET /sync-orders HTTP/1.1" 200 -
```